### PR TITLE
Update haproxy client/server timeouts to 30m each

### DIFF
--- a/playbooks/examples/roles/configure-haproxy/templates/etc/haproxy/haproxy.cfg.j2
+++ b/playbooks/examples/roles/configure-haproxy/templates/etc/haproxy/haproxy.cfg.j2
@@ -26,8 +26,8 @@ defaults
     timeout http-request    10s
     timeout queue           1m
     timeout connect         10s
-    timeout client          1m
-    timeout server          1m
+    timeout client          30m
+    timeout server          30m
     timeout http-keep-alive 10s
     timeout check           10s
     maxconn                 3000


### PR DESCRIPTION
When the bastion host haproxy is setup with only a 1m timeout for client and or server, this may cause active connections to unexpectedly drop without being clear as to why. For example:

> oc debug node/worker-0.test.example.com 

will create a debug pod whose default timeout is 15m (at the time of this PR.) However, after 1 min of inactivity, the debug pod will terminate without any reason provided (in the logs or from the command line) because haproxy on the bastion will terminate the connection. How this appears in the logs is the API server sends a request to the node to terminate the debug pod.

Updating this setting to 30m should prevent unexpected disconnects from happening. Should the user require a longer timeout, the haproxy.cfg can be updated after installation and restart the service.

This PR serves to make the default configuration more robust.  
